### PR TITLE
Fix build & runtime issues for Appium C# Android & iOS projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# =========================
+# Java / JVM
+# =========================
+
 # Compiled class file
 *.class
 
@@ -10,7 +14,7 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files
 *.jar
 *.war
 *.nar
@@ -19,5 +23,42 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# JVM crash logs
 hs_err_pid*
+
+
+# =========================
+# .NET / C# (Android & iOS)
+# =========================
+
+# Build output folders
+[Bb]in/
+[Oo]bj/
+
+# NuGet
+packages/
+*.nupkg
+project.assets.json
+project.nuget.cache
+*.nuget.props
+*.nuget.targets
+
+
+# =========================
+# Visual Studio / IDEs
+# =========================
+
+.vs/
+*.user
+*.suo
+*.rsuser
+*.userosscache
+*.sln.docstates
+
+
+# =========================
+# OS files
+# =========================
+
+.DS_Store
+Thumbs.db

--- a/android/csharp-appium-android/Program.cs
+++ b/android/csharp-appium-android/Program.cs
@@ -13,18 +13,23 @@ namespace csharp_appium
         {
             AppiumOptions caps = new AppiumOptions();
 
-            caps.AddAdditionalCapability("user", "YOUR_LT_USERNAME");  //Add the LT Username
-            caps.AddAdditionalCapability("accessKey", "YOUR_LT_ACCESS_KEY");  //Add the LT Access key
+            // caps.AddAdditionalCapability("user", "YOUR_LT_USERNAME");  //Add the LT Username
+            // caps.AddAdditionalCapability("accessKey", "YOUR_LT_ACCESS_KEY");  //Add the LT Access key
+            caps.AddAdditionalCapability("user", Environment.GetEnvironmentVariable("LT_USERNAME"));
+            caps.AddAdditionalCapability("accessKey", Environment.GetEnvironmentVariable("LT_ACCESS_KEY"));
+
 
             // Set URL of the application under test
-            caps.AddAdditionalCapability("app", "APP_URL"); //Add the App ID
+            caps.AddAdditionalCapability("app", "lt://APP10160311521768935596417357"); //Add the App ID
 
             // Specify device and os_version
-            caps.AddAdditionalCapability("deviceName", "Galaxy S21 Ultra 5G");  //Add the Device Details
-            caps.AddAdditionalCapability("platformVersion", "11");
+            caps.AddAdditionalCapability("deviceName", "Galaxy S25");  //Add the Device Details
+            caps.AddAdditionalCapability("platformVersion", "15");
             caps.AddAdditionalCapability("platformName", "Android");
             caps.AddAdditionalCapability("isRealMobile", true);
             caps.AddAdditionalCapability("network", false);
+            caps.AddAdditionalCapability("autoGrantPermissions", true);
+            caps.AddAdditionalCapability("autoAcceptAlerts", true);
 
             caps.AddAdditionalCapability("project", "CSharp Sample Android");
             caps.AddAdditionalCapability("build", "CSharp Sample Android");
@@ -34,7 +39,7 @@ namespace csharp_appium
             // and desired capabilities defined above
             IOSDriver<IOSElement> driver = new IOSDriver<IOSElement>(
                 new Uri("https://mobile-hub.lambdatest.com/wd/hub"), caps);
-						driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
+                        driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
             // Test case for the sample iOS app. 
             // If you have uploaded your app, update the test case here.
             IOSElement color = (IOSElement)new WebDriverWait(driver, TimeSpan.FromSeconds(30)).Until(

--- a/android/csharp-appium-android/Program.cs
+++ b/android/csharp-appium-android/Program.cs
@@ -20,7 +20,7 @@ namespace csharp_appium
 
 
             // Set URL of the application under test
-            caps.AddAdditionalCapability("app", "lt://APP10160311521768935596417357"); //Add the App ID
+             caps.AddAdditionalCapability("app", "APP_URL"); //Add the App ID
 
             // Specify device and os_version
             caps.AddAdditionalCapability("deviceName", "Galaxy S25");  //Add the Device Details

--- a/android/csharp-appium-android/csharp-appium.csproj
+++ b/android/csharp-appium-android/csharp-appium.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>csharp_appium_first_test</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
   </ItemGroup>

--- a/android/csharp-appium-android/packages.config
+++ b/android/csharp-appium-android/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Appium.WebDriver" version="4.1.1" targetFramework="net461" />
-  <package id="Castle.Core" version="4.4.1" targetFramework="net461" />
-  <package id="DotNetSeleniumExtras.WaitHelpers" version="3.11.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-</packages>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,8 @@
 trigger:
-- main
+- master
 
 pr:
-- main
+- master
 
 # ---------- PARAMETERS ----------
 parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,69 @@
+trigger:
+- main
+
+pr:
+- main
+
+# ---------- PARAMETERS ----------
+parameters:
+- name: platform
+  displayName: "Which project do you want to run?"
+  type: string
+  default: both
+  values:
+    - android
+    - ios
+    - both
+
+# ---------- SCHEDULE ----------
+schedules:
+- cron: "0 2 * * *"   # Daily 2 AM UTC
+  displayName: Nightly Mobile Tests
+  branches:
+    include:
+    - main
+  always: "true"
+
+# ---------- AGENT ----------
+pool:
+  vmImage: ubuntu-latest
+
+# ---------- VARIABLES ----------
+variables:
+- group: lambdatest-secrets
+
+# ---------- STEPS ----------
+steps:
+- task: UseDotNet@2
+  displayName: "Install .NET 8 SDK"
+  inputs:
+    packageType: sdk
+    version: '8.0.x'
+
+# ---------- ANDROID ----------
+- script: |
+    echo "Running Android Appium tests"
+    cd android/csharp-appium-android
+    dotnet restore
+    dotnet build --configuration Release
+    dotnet run --configuration Release
+  displayName: "Run Android Tests"
+  condition: |
+    or(
+      eq('${{ parameters.platform }}', 'android'),
+      eq('${{ parameters.platform }}', 'both')
+    )
+
+# ---------- iOS ----------
+- script: |
+    echo "Running iOS Appium tests"
+    cd ios/csharp-appium-ios
+    dotnet restore
+    dotnet build --configuration Release
+    dotnet run --configuration Release
+  displayName: "Run iOS Tests"
+  condition: |
+    or(
+      eq('${{ parameters.platform }}', 'ios'),
+      eq('${{ parameters.platform }}', 'both')
+    )

--- a/ios/csharp-appium-ios/Program.cs
+++ b/ios/csharp-appium-ios/Program.cs
@@ -13,15 +13,17 @@ namespace csharp_appium_first
         {
             AppiumOptions caps = new AppiumOptions();
 
-            caps.AddAdditionalCapability("user", "YOUR_LT_USERNAME"); //Enter the Username here
-            caps.AddAdditionalCapability("accessKey", "YOUR_LT_ACCESS_KEY");  //Enter the Access key here
+            // caps.AddAdditionalCapability("user", "YOUR_LT_USERNAME"); //Enter the Username here
+            // caps.AddAdditionalCapability("accessKey", "YOUR_LT_ACCESS_KEY");  //Enter the Access key here
+            caps.AddAdditionalCapability("user", Environment.GetEnvironmentVariable("LT_USERNAME"));
+            caps.AddAdditionalCapability("accessKey", Environment.GetEnvironmentVariable("LT_ACCESS_KEY"));
 
             // Set URL of the application under test
-            caps.AddAdditionalCapability("app", "APP_URL"); //Enter the App URL here.
+            caps.AddAdditionalCapability("app", "lt://APP10160591941768565664336296"); //Enter the App URL here.
 
             // Specify device and os_version
-            caps.AddAdditionalCapability("deviceName", "iPhone 12"); //Change the device name here
-            caps.AddAdditionalCapability("platformVersion", "15");
+            caps.AddAdditionalCapability("deviceName", "iPhone 15"); //Change the device name here
+            caps.AddAdditionalCapability("platformVersion", "17");
             caps.AddAdditionalCapability("platformName", "iOS");
             caps.AddAdditionalCapability("isRealMobile", true);
             caps.AddAdditionalCapability("network", false);
@@ -29,10 +31,13 @@ namespace csharp_appium_first
             caps.AddAdditionalCapability("project", "First CSharp project");
             caps.AddAdditionalCapability("build", "CSharp iOS");
             caps.AddAdditionalCapability("name", "first_test");
+            caps.AddAdditionalCapability("autoGrantPermissions", true);
+            caps.AddAdditionalCapability("autoAcceptAlerts", true);
 
             IOSDriver<IOSElement> driver = new IOSDriver<IOSElement>(
                 new Uri("https://mobile-hub.lambdatest.com/wd/hub"), caps);
-            driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
+            // driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
+               driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
             IOSElement color = (IOSElement)new WebDriverWait(driver, TimeSpan.FromSeconds(30)).Until(
                 SeleniumExtras.WaitHelpers.ExpectedConditions.ElementToBeClickable(MobileBy.Id("color"))
             );

--- a/ios/csharp-appium-ios/Program.cs
+++ b/ios/csharp-appium-ios/Program.cs
@@ -19,7 +19,7 @@ namespace csharp_appium_first
             caps.AddAdditionalCapability("accessKey", Environment.GetEnvironmentVariable("LT_ACCESS_KEY"));
 
             // Set URL of the application under test
-            caps.AddAdditionalCapability("app", "lt://APP10160591941768565664336296"); //Enter the App URL here.
+             caps.AddAdditionalCapability("app", "APP_URL"); //Add the App ID
 
             // Specify device and os_version
             caps.AddAdditionalCapability("deviceName", "iPhone 15"); //Change the device name here

--- a/ios/csharp-appium-ios/csharp-appium-first.csproj
+++ b/ios/csharp-appium-ios/csharp-appium-first.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>csharp_appium_first_ios</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>

--- a/ios/csharp-appium-ios/packages.config
+++ b/ios/csharp-appium-ios/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Appium.WebDriver" version="4.1.1" targetFramework="net461" />
-  <package id="Castle.Core" version="4.4.1" targetFramework="net461" />
-  <package id="DotNetSeleniumExtras.WaitHelpers" version="3.11.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Fixed runtime crash by removing unsupported script timeout, upgraded project to .NET 8, and cleaned up legacy package config for stable execution on Android & iOS.
